### PR TITLE
create type for irrationals, reconfigure iterators

### DIFF
--- a/src/ContinuedFractions.jl
+++ b/src/ContinuedFractions.jl
@@ -1,57 +1,15 @@
 module ContinuedFractions
 
-import Base: start, done, next, length, eltype, collect
+import Base: start, done, next, length, eltype, getindex
 
-export ContinuedFraction, quotients, convergents, ConvergentIterator
+export ContinuedFraction, FiniteContinuedFraction, IrrationalContinuedFraction,
+    ConvergentIterator, continuedfraction, convergents
 
-immutable ContinuedFraction{T<:Integer}
-	quotients::Vector{T}
-end
+abstract ContinuedFraction{T<:Integer}
+eltype{T}(::ContinuedFraction{T}) = T
 
-quotients(cf::ContinuedFraction) = cf.quotients
-
-immutable ConvergentIterator{T<:Integer}
-    qs::Vector{T}
-end
-
-start(::ConvergentIterator) = 1
-done(it::ConvergentIterator, state::Int) = state > length(it.qs)
-length(it::ConvergentIterator) = length(it.qs)
-
-function next(it::ConvergentIterator, state::Int)
-    convergent = Rational(ContinuedFraction(it.qs[1:state]))
-    convergent, state + 1
-end
-
-eltype(it::ConvergentIterator) = Rational{eltype(it.qs)}
-collect(it::ConvergentIterator) = collect(eltype(it), it)
-
-convergents(cf::ContinuedFraction) = convergents(quotients(cf))
-convergents{T<:Integer}(qs::Vector{T}) = ConvergentIterator(qs)
-
-function Base.Rational(cf::ContinuedFraction)
-    qs = quotients(cf)
-    isempty(qs) && return 0 // 1
-    length(qs) == 1 && return qs[1] // 1
-
-    remainder = qs[2:end]
-    rat = Rational(ContinuedFraction(remainder))
-    (qs[1] * rat.num + rat.den) // rat.num
-end
-
-function ContinuedFraction{T<:Integer}(rat::Rational{T})
-    a = div(rat.num, rat.den)
-    a * rat.den == rat.num && return ContinuedFraction(T[a])  # Exact!
-
-    cf = ContinuedFraction(rat.den//(rat.num - a*rat.den))
-    unshift!(quotients(cf), a) # insert at index 1
-    cf
-end
-
-# let rationalize handle conversion from floating point
-ContinuedFraction(x::BigFloat) = ContinuedFraction(rationalize(BigInt, x))
-ContinuedFraction(x::FloatingPoint) = ContinuedFraction(rationalize(x))
-
-ContinuedFraction(x::Integer) = ContinuedFraction([x])
+include("finite.jl")
+include("irrational.jl")
+include("convergents.jl")
 
 end # module ContinuedFractions

--- a/src/convergents.jl
+++ b/src/convergents.jl
@@ -1,0 +1,22 @@
+immutable ConvergentIterator{T<:Integer,CF<:ContinuedFraction}
+    cf::CF
+end
+
+ConvergentIterator{T}(cf::ContinuedFraction{T}) = ConvergentIterator{T,typeof(cf)}(cf)
+
+convergents(x::Real) = ConvergentIterator(continuedfraction(x))
+
+start{T,CF}(it::ConvergentIterator{T,CF}) = start(it.cf), one(T)//zero(T), zero(T)//one(T)
+done(it::ConvergentIterator, state) = done(it.cf, state[1])
+
+length(it::ConvergentIterator) = length(it.cf)
+
+function next(it::ConvergentIterator, state)
+    i, r, r_p  = state
+    q, i_n = next(it.cf, i)
+    r_n = (q*r.num + r_p.num) // (q*r.den + r_p.den)
+    return r_n, (i_n, r_n, r)
+end
+
+eltype{T,CF}(it::ConvergentIterator{T,CF}) = Rational{T}
+

--- a/src/finite.jl
+++ b/src/finite.jl
@@ -1,0 +1,30 @@
+# rationals have finite continued fractions
+immutable FiniteContinuedFraction{T<:Integer} <: ContinuedFraction{T}
+    quotients::Vector{T}
+end
+
+# continued fraction for the ratio of x and y
+function continuedfraction{T<:Integer}(x::Real, y::Real, ::Type{T}=Int)
+    qs = T[]
+    r = y
+    r_p = x
+
+    while r != 0
+        q, r_n = divrem(r_p, r)
+        push!(qs, q)
+        r, r_p = r_n, r
+    end
+    FiniteContinuedFraction(qs)
+end
+
+continuedfraction{T<:Integer}(x::FloatingPoint, ::Type{T}=Int) =
+    continuedfraction(x, one(x), T)
+
+continuedfraction{T<:Integer}(x::Rational, ::Type{T}=Int) =
+    continuedfraction(x.num, x.den, T)                 
+
+start(cf::FiniteContinuedFraction) = start(cf.quotients)
+done(cf::FiniteContinuedFraction) = done(cf.quotients)
+next(cf::FiniteContinuedFraction, i) = next(cf.quotients,i)
+getindex(cf::FiniteContinuedFraction, i) = getindex(cf.quotients, i)
+length(cf::FiniteContinuedFraction) = length(cf.quotients)

--- a/src/irrational.jl
+++ b/src/irrational.jl
@@ -1,0 +1,70 @@
+type IrrationalContinuedFraction{T<:Integer, C} <: ContinuedFraction{T}
+    precision::Int
+    quotients::Vector{T}
+end
+
+eps_error(c::MathConst) = 2<<20 # assume accurate to within 20 bits?
+
+function compute!{T,C}(cf::IrrationalContinuedFraction{T,C}, prec::Int)
+    with_bigfloat_precision(prec) do
+        qs = T[]
+        r = big(1.0)
+        r_p = big(C())
+        
+        ϵ = big(0.0)
+        ϵ_p = eps(r_p) * eps_error(C())
+
+        while true
+            a, r_n = divrem(r_p, r)
+            ϵ_n = ϵ_p + a*ϵ
+            if r_n < ϵ_n || r-r_n < ϵ_n
+                break
+            end
+            push!(qs,a)
+            r, r_p = r_n, r
+            ϵ, ϵ_p = ϵ_n, ϵ
+        end
+        cf.precision = prec
+        cf.quotients = qs
+    end
+    cf
+end
+
+function continuedfraction{T<:Integer}(c::MathConst, ::Type{T}=Int)
+    cf = IrrationalContinuedFraction{T,typeof(c)}(get_bigfloat_precision(),T[])
+end
+
+start(cf::IrrationalContinuedFraction) = 1
+done(cf::IrrationalContinuedFraction, i::Int) = false
+next(cf::IrrationalContinuedFraction, i::Int) = cf[i], i+1
+
+function getindex(cf::IrrationalContinuedFraction, i::Integer)    
+    while i > length(cf.quotients)
+        # keep doubling precision until sufficient accuracy obtained
+        compute!(cf, cf.precision*2)
+    end
+    cf.quotients[i]
+end
+
+function getindex(cf::IrrationalContinuedFraction, r::AbstractVector)
+    [cf[i] for i in r]
+end
+
+
+# cases with known patterns
+function getindex{T<:Integer}(::IrrationalContinuedFraction{T,MathConst{:e}}, i::Integer)
+    i >= 1 || throw(BoundsError())
+    if i==1
+        2
+    elseif i % 3 == 0
+        2*div(i,3)
+    else
+        1
+    end
+end
+
+function getindex{T<:Integer}(::IrrationalContinuedFraction{T,MathConst{:φ}}, i::Integer)
+    i >= 1 || throw(BoundsError())
+    1
+end
+

--- a/test/cmp_oeis.jl
+++ b/test/cmp_oeis.jl
@@ -1,0 +1,32 @@
+using OEIS
+using Iterators
+
+function test_cf_oeis(c,id)
+    # quotients of pi
+    s = oeis(id)
+    for (o,q) = zip(s.values, continuedfraction(c))
+        @test o == q
+    end
+end
+
+function test_conv_oeis(c, idn, idd, ofn=0, ofd=ofn)
+    sn = oeis(idn)
+    sd = oeis(idd)
+    for (on,od,r) in zip(sn.values[(ofn+1):end], sd.values[(ofd+1):end], convergents(c))
+        @test on//od == r
+    end
+end
+
+test_cf_oeis(pi, :A001203)
+test_cf_oeis(e,  :A003417)
+test_cf_oeis(γ,  :A002852)
+test_cf_oeis(catalan, :A014538)
+test_cf_oeis(golden, :A000012)
+
+test_conv_oeis(pi, :A002485, :A002486, 2)
+test_conv_oeis(e,  :A007676, :A007677)
+test_conv_oeis(γ,  :A046114, :A046115)
+test_conv_oeis(catalan,  :A153069, :A153070, 2)
+test_conv_oeis(golden, :A000045, :A000045, 2, 1)
+
+# 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,4 @@
+using Base.Test
+using ContinuedFractions
+
+include("cmp_oeis.jl")


### PR DESCRIPTION
This is not quite ready to be merged, but I thought I would get your thoughts. It changes a few things to allow for infinite length expansions for irrational numbers.

Still to do:
* Add a `QuadraticSurd` type for repeating expansions.
* Docs and tests.