### PR TITLE
test julia 0.4-0.7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: julia
 os:
     - linux
-    - osx
 julia: 
     - 0.4
+    - 0.5
+    - 0.6
     - nightly
 notifications:
     email: false


### PR DESCRIPTION
Also disable OSX tests on Travis, since they're a scarce resource and not very informative for a pure-julia package. 