### PR TITLE
Add Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,6 @@
+name = "ContinuedFractions"
+uuid = "900c1893-6c27-45fc-afb6-16d84d79c500"
+version = "0.1"
+
+[compat]
+julia = "≥ 0.7"


### PR DESCRIPTION
Make it possible to install the package using Pkg3, whereas currently the package manager unexpectedly adds an incompatible package by @jwscook, causing confusion and frustration.

### Adding the package that `ContinuedFractions` resolves to by default
```
(@v1.4) pkg> add ContinuedFractions#master
    Cloning git-repo `https://github.com/jwscook/ContinuedFractions.jl.git`
   Updating git-repo `https://github.com/jwscook/ContinuedFractions.jl.git`
  Resolving package versions...
   Updating `~/.julia/environments/v1.4/Project.toml`
  [11738ef7] + ContinuedFractions v0.1.0 #master (https://github.com/jwscook/ContinuedFractions.jl.git)
   Updating `~/.julia/environments/v1.4/Manifest.toml`
  [11738ef7] + ContinuedFractions v0.1.0 #master (https://github.com/jwscook/ContinuedFractions.jl.git)
```

### Trying to add [this repo](https://github.com/johnmyleswhite/ContinuedFractions.jl) manually
```
(@v1.4) pkg> add https://github.com/johnmyleswhite/ContinuedFractions.jl
    Cloning git-repo `https://github.com/johnmyleswhite/ContinuedFractions.jl`
   Updating git-repo `https://github.com/johnmyleswhite/ContinuedFractions.jl`
ERROR: could not find project file in package at https://github.com/johnmyleswhite/ContinuedFractions.jl
```